### PR TITLE
Enforce group-based milestone assignment visibility and updates

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SetMilestoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetMilestoneCommand.java
@@ -32,6 +32,8 @@ public class SetMilestoneCommand extends Command {
 
     public static final String MESSAGE_STUDENT_NOT_FOUND = "Student not found: %1$s";
     public static final String MESSAGE_ASSIGNMENT_NOT_FOUND = "Assignment not found: %1$s";
+    public static final String MESSAGE_ASSIGNMENT_NOT_IN_STUDENT_GROUP =
+            "Assignment %1$s does not belong to student %2$s's group.";
 
     private final StudentId studentId;
     private final AssignmentId assignmentId;
@@ -58,12 +60,19 @@ public class SetMilestoneCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (!hasStudent(model, studentId)) {
+        Person student = findStudent(model, studentId);
+        if (student == null) {
             throw new CommandException(String.format(MESSAGE_STUDENT_NOT_FOUND, studentId));
         }
 
-        if (!hasAssignment(model, assignmentId)) {
+        Assignment assignment = findAssignment(model, assignmentId);
+        if (assignment == null) {
             throw new CommandException(String.format(MESSAGE_ASSIGNMENT_NOT_FOUND, assignmentId));
+        }
+
+        if (!student.getGroups().contains(assignment.getGroup())) {
+            throw new CommandException(String.format(
+                    MESSAGE_ASSIGNMENT_NOT_IN_STUDENT_GROUP, assignmentId, studentId));
         }
 
         model.setMilestone(studentId, assignmentId, status, completedAt);
@@ -74,27 +83,27 @@ public class SetMilestoneCommand extends Command {
     }
 
     /**
-     * Returns true if the student exists in the model.
+     * Returns the student with the given student ID, or null if not found.
      */
-    private boolean hasStudent(Model model, StudentId studentId) {
+    private Person findStudent(Model model, StudentId studentId) {
         for (Person person : model.getAddressBook().getPersonList()) {
             if (person.getStudentId().equals(studentId)) {
-                return true;
+                return person;
             }
         }
-        return false;
+        return null;
     }
 
     /**
-     * Returns true if the assignment exists in the model.
+     * Returns the assignment with the given assignment ID, or null if not found.
      */
-    private boolean hasAssignment(Model model, AssignmentId assignmentId) {
+    private Assignment findAssignment(Model model, AssignmentId assignmentId) {
         for (Assignment assignment : model.getAssignmentList()) {
             if (assignment.getAssignmentId().equals(assignmentId)) {
-                return true;
+                return assignment;
             }
         }
-        return false;
+        return null;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -165,10 +165,15 @@ public class ModelManager implements Model {
     public StudentMilestoneView getResolvedMilestones(StudentId studentId) {
         requireNonNull(studentId);
 
+        Person student = findStudentById(studentId);
         StudentMilestones studentMilestones = getMilestones(studentId);
-        List<Assignment> assignments = new ArrayList<>(getAssignmentList());
 
-        return milestoneResolver.resolveForStudent(studentId, assignments, studentMilestones);
+        if (student == null) {
+            return milestoneResolver.resolveForStudent(studentId, List.of(), studentMilestones);
+        }
+
+        List<Assignment> assignmentsForStudentGroup = getAssignmentsForStudent(student);
+        return milestoneResolver.resolveForStudent(studentId, assignmentsForStudentGroup, studentMilestones);
     }
 
     @Override
@@ -197,6 +202,43 @@ public class ModelManager implements Model {
         return addressBook.getMilestoneStore()
                 .getMilestone(studentId, assignmentId)
                 .orElse(null);
+    }
+
+    /**
+     * Finds the student with the given student ID from the address book.
+     *
+     * @param studentId The student ID to search for.
+     * @return The matching student, or null if not found.
+     */
+    private Person findStudentById(StudentId studentId) {
+        requireNonNull(studentId);
+
+        for (Person person : addressBook.getPersonList()) {
+            if (person.getStudentId().equals(studentId)) {
+                return person;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the assignments that belong to at least one of the student's groups.
+     *
+     * @param student The student whose assignments should be returned.
+     * @return A list of assignments matching the student's groups.
+     */
+    private List<Assignment> getAssignmentsForStudent(Person student) {
+        requireNonNull(student);
+
+        List<Assignment> matchingAssignments = new ArrayList<>();
+
+        for (Assignment assignment : getAssignmentList()) {
+            if (student.getGroups().contains(assignment.getGroup())) {
+                matchingAssignments.add(assignment);
+            }
+        }
+
+        return matchingAssignments;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/GetStudentMilestonesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GetStudentMilestonesCommandTest.java
@@ -31,9 +31,10 @@ public class GetStudentMilestonesCommandTest {
                 .withPhone("94351253")
                 .withEmail("alice@example.com")
                 .withStudentId("S1")
+                .withGroups("G1")
                 .build();
 
-        Assignment assignment = createAssignment("A1", "Quiz 1", "G1", "2026-04-01", "1");
+        Assignment assignment = createAssignment("A1", "Quiz 1", "G1", "2026-04-01");
 
         addressBook.addPerson(student);
         addressBook.addAssignment(assignment);
@@ -86,14 +87,50 @@ public class GetStudentMilestonesCommandTest {
         assertEquals("There are no assignments in the system.", result.getFeedbackToUser());
     }
 
+    @Test
+    public void execute_onlySameGroupAssignmentsShown_success() throws Exception {
+        AddressBook addressBook = new AddressBook();
+
+        Person student = new PersonBuilder()
+                .withName("Alice Pauline")
+                .withPhone("94351253")
+                .withEmail("alice@example.com")
+                .withStudentId("S1")
+                .withGroups("G1")
+                .build();
+
+        Assignment matchingAssignment = createAssignment("A1", "Quiz 1", "G1", "2026-04-01");
+        Assignment nonMatchingAssignment = createAssignment("A2", "Quiz 2", "G2", "2026-04-02");
+
+        addressBook.addPerson(student);
+        addressBook.addAssignment(matchingAssignment);
+        addressBook.addAssignment(nonMatchingAssignment);
+
+        Model model = new ModelManager(addressBook, new UserPrefs());
+        GetStudentMilestonesCommand command = new GetStudentMilestonesCommand(new StudentId("S1"));
+
+        CommandResult result = command.execute(model);
+        String feedback = result.getFeedbackToUser();
+
+        assertContains(feedback, "A1");
+        assertDoesNotContain(feedback, "A2");
+    }
+
     private Assignment createAssignment(String assignmentId, String label, String group,
-                                        String dueDate, String order) {
+                                        String dueDate) {
         return new Assignment(
                 new AssignmentId(assignmentId),
                 new Label(label),
                 new Group(group),
                 new DueDate(dueDate)
         );
+    }
+
+    private void assertDoesNotContain(String actual, String unexpectedSubstring) {
+        if (actual.contains(unexpectedSubstring)) {
+            throw new AssertionError("Did not expect to find substring:\n"
+                    + unexpectedSubstring + "\ninside:\n" + actual);
+        }
     }
 
     private void assertContains(String actual, String expectedSubstring) {

--- a/src/test/java/seedu/address/logic/commands/SetMilestoneCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SetMilestoneCommandTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.assignment.Assignment;
+import seedu.address.model.assignment.AssignmentId;
+import seedu.address.model.assignment.DueDate;
+import seedu.address.model.assignment.Label;
+import seedu.address.model.group.Group;
+import seedu.address.model.milestone.CompletedAt;
+import seedu.address.model.milestone.MilestoneRecord;
+import seedu.address.model.milestone.MilestoneStatus;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
+import seedu.address.testutil.PersonBuilder;
+
+public class SetMilestoneCommandTest {
+
+    @Test
+    public void execute_sameGroupAssignment_success() throws Exception {
+        AddressBook addressBook = new AddressBook();
+
+        Person student = new PersonBuilder()
+                .withName("Alice Pauline")
+                .withPhone("94351253")
+                .withEmail("alice@example.com")
+                .withStudentId("S1")
+                .withGroups("G1")
+                .build();
+
+        Assignment assignment = createAssignment("A1", "Quiz 1", "G1", "2026-04-01");
+
+        addressBook.addPerson(student);
+        addressBook.addAssignment(assignment);
+
+        Model model = new ModelManager(addressBook, new UserPrefs());
+        SetMilestoneCommand command = new SetMilestoneCommand(
+                new StudentId("S1"),
+                new AssignmentId("A1"),
+                MilestoneStatus.COMPLETED,
+                new CompletedAt("2026-03-30T1200H")
+        );
+
+        CommandResult result = command.execute(model);
+
+        MilestoneRecord storedRecord = model.getMilestone(new StudentId("S1"), new AssignmentId("A1"));
+        assertEquals(MilestoneStatus.COMPLETED, storedRecord.getStatus());
+        assertEquals("2026-03-30T1200H", storedRecord.getCompletedAt().getValue());
+        assertEquals("Set milestone for student S1 and assignment A1: COMPLETED, completedAt=2026-03-30T1200H",
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_differentGroupAssignment_throwsCommandException() {
+        AddressBook addressBook = new AddressBook();
+
+        Person student = new PersonBuilder()
+                .withName("Alice Pauline")
+                .withPhone("94351253")
+                .withEmail("alice@example.com")
+                .withStudentId("S1")
+                .withGroups("G1")
+                .build();
+
+        Assignment assignment = createAssignment("A1", "Quiz 1", "G2", "2026-04-01");
+
+        addressBook.addPerson(student);
+        addressBook.addAssignment(assignment);
+
+        Model model = new ModelManager(addressBook, new UserPrefs());
+        SetMilestoneCommand command = new SetMilestoneCommand(
+                new StudentId("S1"),
+                new AssignmentId("A1"),
+                MilestoneStatus.NOT_STARTED,
+                new CompletedAt("")
+        );
+
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    private Assignment createAssignment(String assignmentId, String label, String group, String dueDate) {
+        return new Assignment(
+                new AssignmentId(assignmentId),
+                new Label(label),
+                new Group(group),
+                new DueDate(dueDate)
+        );
+    }
+}


### PR DESCRIPTION
Tldr: Integrate group into milestones, now only milestones belonging to the group is shown

Filter resolved milestones so each student only receives assignments from their own group, and reject set milestone commands for assignments outside the student's group. Update tests to cover same-group filtering and cross-group validation.