### PR TITLE
Bugfix issue #230 legal name not allowed

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -213,6 +213,8 @@ Rules:
 * The phone number must be within 3-15 digits.
 * The email should contain `@`.
 * The name, phone, email, and group fields must not contain `;`.
+* The name must start with an alphanumeric character and may include whitespace, `.`,
+      `/`, `'`, and `-`.
 * The groups field supports multiple groups separated by commas.
 
 Examples:

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,16 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            """
+            Names should only contain alphanumeric characters, spaces, periods, forward slashes, hyphens
+            Names should not be blank and the first character of a name must be alphanumeric
+            Consecutive spaces within a name are auto-formatted to 1 space""";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ./'-]*";
 
     public final String fullName;
 
@@ -27,8 +30,9 @@ public class Name {
      */
     public Name(String name) {
         requireNonNull(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        String trimmed = name.trim().replaceAll(" +", " ");
+        checkArgument(isValidName(trimmed), MESSAGE_CONSTRAINTS);
+        fullName = trimmed;
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,9 +29,17 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName(".Jean-Luc")); // first char must not be alphanumeric
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
+        assertTrue(Name.isValidName("Jack O'Connor")); // alphabets and apostrophe
+        assertTrue(Name.isValidName("Jean-Luc")); //alphabets and hyphen
+        assertTrue(new Name("   brotato  'chip    ..  ").fullName.equals("brotato 'chip .."));
+        // name with extra spaces and period and apostrophe
+        assertTrue(Name.isValidName("Subramaniam s/o K.V. Sathasivam")); // name with slash and periods
+        assertTrue(new Name("peter  jack").fullName.equals("peter jack")); // extra spaces collapsed
+        assertTrue(new Name("     peter jack    ").fullName.equals("peter jack")); // leading/trailing spaces trimmed
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -37,10 +37,10 @@ public class PersonTest {
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertFalse(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true (spaces are trimmed)
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         //same phone
         editedAlice = new PersonBuilder(BOB).withPhone(ALICE.getPhone().value).build();


### PR DESCRIPTION
Updated valid name constraints:
- Name must not start with alphanumeric char
- Name may have "-" and "." and "/"
- Extra before and trailing whitespaces are auto-trimmed
- Extra spaces in between alphanumeric/special characters are auto formatted to 1 space "a    b" to "a b"